### PR TITLE
Fix scheduled workflow not running

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -26,6 +26,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
         run: ./news
 
       - name: Commit state changes
@@ -37,3 +38,6 @@ jobs:
           git commit -m "Update state.json"
           git pull --rebase
           git push
+
+      - name: Keepalive
+        uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
## Summary
- GitHub Actionsのスケジュール実行が動作しない問題を修正
- `gautamkrishnar/keepalive-workflow@v2` を追加し、60日間の非アクティブによるスケジュールワークフロー自動無効化を防止
- `NOTION_API_KEY` 環境変数の欠落を修正

## 原因
GitHubはリポジトリに60日間アクティビティがないと、スケジュールワークフローを自動で無効化します。このワークフローファイルの更新pushにより再有効化されます。keepaliveアクションにより今後の再発を防止します。

## Test plan
- [ ] mainにマージ後、GitHub Actions UIでワークフローが "enabled" になっていることを確認
- [ ] 翌日UTC 9:00（JST 18:00）にスケジュール実行されることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)